### PR TITLE
Enforce to redirect to the self-hosted login page when users are not authenticated

### DIFF
--- a/self-hosted-login/okta-aspnetcore-mvc-example/Program.cs
+++ b/self-hosted-login/okta-aspnetcore-mvc-example/Program.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
+﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 #pragma warning disable SA1300 // Element should begin with upper-case letter
 namespace okta_aspnetcore_mvc_example

--- a/self-hosted-login/okta-aspnetcore-mvc-example/Startup.cs
+++ b/self-hosted-login/okta-aspnetcore-mvc-example/Startup.cs
@@ -31,19 +31,19 @@ namespace okta_aspnetcore_mvc_example
             });
 
             services.AddAuthentication(options =>
-            {
-                options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = OktaDefaults.MvcAuthenticationScheme;
-            })
-            .AddCookie()
-            .AddOktaMvc(new OktaMvcOptions
-            {
-                // Replace these values with your Okta configuration
-                OktaDomain = Configuration.GetValue<string>("Okta:OktaDomain"),
-                ClientId = Configuration.GetValue<string>("Okta:ClientId"),
-                ClientSecret = Configuration.GetValue<string>("Okta:ClientSecret"),
-            });
+                {
+                    options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                    options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                    options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                })
+                .AddCookie(o => { o.LoginPath = new PathString("/Account/SignIn"); })
+                .AddOktaMvc(new OktaMvcOptions
+                 {
+                     // Replace these values with your Okta configuration
+                     OktaDomain = Configuration.GetValue<string>("Okta:OktaDomain"),
+                     ClientId = Configuration.GetValue<string>("Okta:ClientId"),
+                     ClientSecret = Configuration.GetValue<string>("Okta:ClientSecret"),
+                 });
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
         }


### PR DESCRIPTION
When not authenticated users tried to access a controller decorated with `[Authorize]` attribute it was redirecting to the Okta login page instead of the self-hosted login page.

More details: https://github.com/okta/okta-aspnet/issues/77.

To test this, decorate any of the actions available in the Home page (for example, `Privacy`) with `Authorize` and try to access it without being authenticated. It should redirect to the self-hosted login page.