### PR TITLE
fix: resolved core-js vulnerability by upgrading wait-on package

### DIFF
--- a/samples-aspnetcore-3x/e2e-tests/package.json
+++ b/samples-aspnetcore-3x/e2e-tests/package.json
@@ -27,7 +27,7 @@
     "jasmine-reporters": "^2.2.0",
     "platform": "^1.3.5",
     "protractor": "^5.4",
-    "wait-on": "^2.0.2"
+    "wait-on": "^8.0.1"
   },
   "overrides": {
     "fsevents": "^2.3.3"


### PR DESCRIPTION
Upgraded wait-on from version 2.0.2 as the previous version was using core-is which was no longer maintained which helped to resolve the vulnerability.