### PR TITLE
Fixed fsevents vulnerability and updated forever-monitor

### DIFF
--- a/samples-aspnetcore-3x/e2e-tests/package.json
+++ b/samples-aspnetcore-3x/e2e-tests/package.json
@@ -23,11 +23,14 @@
   "devDependencies": {
     "dotenv": "^5.0.1",
     "find-process": "^1.1.0",
-    "forever-monitor": "^1.7.1",
+    "forever-monitor": "^3.0.3",
     "jasmine-reporters": "^2.2.0",
     "platform": "^1.3.5",
     "protractor": "^5.4",
     "wait-on": "^2.0.2"
+  },
+  "overrides": {
+    "fsevents": "^2.3.3"
   },
   "bin": {},
   "private": true


### PR DESCRIPTION
This pull request addresses a security vulnerability in the samples-aspnet project caused by an outdated dependency,
fsevents@1.2.9. The issue originates from the dependency tree:

forever-monitor → chokidar → fsevents.
To resolve this:

An overrides field has been added to the package.json to explicitly update fsevents to a secure version (2.3.3).
Updated forever-monitor dependency.